### PR TITLE
📝 Use CommandLine component in command documentation

### DIFF
--- a/docs/components/mdx/command-line.tsx
+++ b/docs/components/mdx/command-line.tsx
@@ -1,11 +1,6 @@
 "use client";
 
 import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from "@/components/ui/popover";
-import {
     Check,
     CircleAlert,
     CircleCheckBig,
@@ -35,85 +30,45 @@ export const CommandLine: React.FC<CommandLineProps> = ({ command }) => {
 
     const getBadgeStyle = (status: string): string => {
         const styles: { [key: string]: string } = {
-            proposal: "mr-12 text-gray-700",
-            beta: "mr-12 text-orange-800",
-            newly: "mr-12 text-blue-800",
-            stable: "mr-12 text-green-800",
-            deprecated: "mr-12 text-red-800",
+            proposal: "mr-4 text-gray-700",
+            beta: "mr-4 text-orange-800",
+            newly: "mr-4 text-blue-800",
+            stable: "mr-4 text-green-800",
+            deprecated: "mr-4 text-red-800",
         };
         return styles[status] || "";
     };
 
+    // ステータスに対応するアイコンを返す
+    const StatusIcon = () => {
+        const iconProps = { className: getBadgeStyle(command.status) };
+        switch (command.status) {
+            case "proposal":
+                return <HandHelping {...iconProps} />;
+            case "beta":
+                return <CircleAlert {...iconProps} />;
+            case "newly":
+                return <Check {...iconProps} />;
+            case "stable":
+                return <CircleCheckBig {...iconProps} />;
+            case "deprecated":
+                return <CircleX {...iconProps} />;
+            default:
+                return null;
+        }
+    };
+
     return (
-        <>
-            <Popover>
-                <PopoverTrigger className={getCommandLineStyle(command.status)}>
-                    <div
-                        className={`flex items-center ${getCommandLineStyle(command.status)}`}
-                    >
-                        <div className="flex items-center ml-8">
-                            {command.status === "proposal" && (
-                                <HandHelping
-                                    className={getBadgeStyle(command.status)}
-                                />
-                            )}
-                            {command.status === "beta" && (
-                                <CircleAlert
-                                    className={getBadgeStyle(command.status)}
-                                />
-                            )}
-                            {command.status === "newly" && (
-                                <Check
-                                    className={getBadgeStyle(command.status)}
-                                />
-                            )}
-                            {command.status === "stable" && (
-                                <CircleCheckBig
-                                    className={getBadgeStyle(command.status)}
-                                />
-                            )}
-                            {command.status === "deprecated" && (
-                                <CircleX
-                                    className={getBadgeStyle(command.status)}
-                                />
-                            )}
-                            <span className="text-black">
-                                {command.command}
-                            </span>
-                        </div>
-                    </div>
-                </PopoverTrigger>
-                <PopoverContent className="text-fd-foreground bg-fd-popover">
-                    <div className="flex flex-col gap-2">
-                        <div className="flex items-center gap-2">
-                            <span className="font-medium">
-                                {command.status === "proposal" &&
-                                    "提案中のコマンド"}
-                                {command.status === "beta" &&
-                                    "ベータ版のコマンド"}
-                                {command.status === "newly" && "新しいコマンド"}
-                                {command.status === "stable" &&
-                                    "安定版のコマンド"}
-                                {command.status === "deprecated" &&
-                                    "非推奨のコマンド"}
-                            </span>
-                        </div>
-                        <div className="h-px bg-fd-border" />
-                        <div className="flex flex-col gap-1">
-                            <p className="text-sm">
-                                エイリアス: {command.aliases.join(", ")}
-                            </p>
-                            <p className="text-sm mb-0">
-                                パーミッション: {command.permission}
-                            </p>
-                        </div>
-                    </div>
-                </PopoverContent>
-            </Popover>
-            <p className="pt-2 pl-8 text-fd-foreground">
-                説明: {command.description}{" "}
-                {command.tags.includes("player") ? "" : "(管理者向け)"}
-            </p>
-        </>
+        <div className={`flex items-center ${getCommandLineStyle(command.status)}`}>
+            <div className="flex items-center ml-8">
+                <StatusIcon />
+                <span className="text-black">{command.command}</span>
+                {command.aliases.length > 0 && (
+                    <span className="ml-4 text-black/60 text-sm">
+                        ({command.aliases.join(", ")})
+                    </span>
+                )}
+            </div>
+        </div>
     );
 };

--- a/docs/components/mdx/command-list.tsx
+++ b/docs/components/mdx/command-list.tsx
@@ -13,14 +13,10 @@ const ranking = ["stable", "newly", "beta", "proposal", "deprecated"];
 export const CommandList: React.FC<CommandListProps> = ({
     list,
 }: CommandListProps) => {
-    const sortedList = list.sort((a, b) =>
-        b.tags.sort().join(",").localeCompare(a.tags.sort().join(",")),
-    );
-
     return (
         <div>
             {ranking.map((rank) =>
-                sortedList
+                list
                     .filter((item) => item.status === rank)
                     .map((item) => (
                         <div key={item.command} className="pb-2">

--- a/docs/content/docs/administrator/commands.mdx
+++ b/docs/content/docs/administrator/commands.mdx
@@ -10,65 +10,102 @@ description: サーバー管理者向けコマンドの一覧
 
 プレイヤーの残高を直接操作するコマンドです。
 
-### `/kerria set <player> <amount> [currencyId]`
+<CommandLine command={{
+  command: "/kerria set <player> <amount> [currencyId]",
+  description: "指定したプレイヤーの残高を直接設定します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.economy",
+  status: "stable"
+}} />
 
-指定したプレイヤーの残高を直接設定します。
+<CommandLine command={{
+  command: "/kerria give <player> <amount> [currencyId]",
+  description: "指定したプレイヤーに金額を付与します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.economy",
+  status: "stable"
+}} />
 
-- **パーミッション:** `kerria.admin.economy`
+<CommandLine command={{
+  command: "/kerria take <player> <amount> [currencyId]",
+  description: "指定したプレイヤーから金額を徴収します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.economy",
+  status: "stable"
+}} />
 
-### `/kerria give <player> <amount> [currencyId]`
-
-指定したプレイヤーに金額を付与します。
-
-- **パーミッション:** `kerria.admin.economy`
-
-### `/kerria take <player> <amount> [currencyId]`
-
-指定したプレイヤーから金額を徴収します。残高が不足している場合はエラーになります。
-
-- **パーミッション:** `kerria.admin.economy`
+残高が不足している場合、takeコマンドはエラーになります。
 
 ## 取引履歴の閲覧
 
-### `/kerria log player <player> [page]`
-
-指定したプレイヤーの取引履歴を表示します。
-
-- **パーミッション:** `kerria.admin.log`
+<CommandLine command={{
+  command: "/kerria log player <player> [page]",
+  description: "指定したプレイヤーの取引履歴を表示します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.log",
+  status: "stable"
+}} />
 
 ## 通貨管理
 
-### `/kerria currency create <name> <symbol> [decimals]`
+<CommandLine command={{
+  command: "/kerria currency create <name> <symbol> [decimals]",
+  description: "新しい通貨を登録します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.currency",
+  status: "stable"
+}} />
 
-新しい通貨を登録します。
 `decimals` は小数点以下の桁数で、省略時は 2 になります。
 フォーマットはデフォルトで `%amount% <name>` が設定されます。
 
-- **パーミッション:** `kerria.admin.currency`
+<CommandLine command={{
+  command: "/kerria currency delete <name>",
+  description: "通貨を削除します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.currency",
+  status: "stable"
+}} />
 
-### `/kerria currency delete <name>`
+デフォルト通貨は削除できません。
 
-通貨を削除します。デフォルト通貨は削除できません。
+<CommandLine command={{
+  command: "/kerria currency list",
+  description: "登録されている全通貨の一覧を表示します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.currency",
+  status: "stable"
+}} />
 
-- **パーミッション:** `kerria.admin.currency`
+ID・名前・記号・小数桁数が確認できます。
 
-### `/kerria currency list`
+<CommandLine command={{
+  command: "/kerria currency info <name>",
+  description: "指定した通貨の詳細情報を表示します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.currency",
+  status: "stable"
+}} />
 
-登録されている全通貨の一覧を表示します。ID・名前・記号・小数桁数が確認できます。
-
-- **パーミッション:** `kerria.admin.currency`
-
-### `/kerria currency info <name>`
-
-指定した通貨の詳細情報を表示します。フォーマット設定や表示例も確認できます。
-
-- **パーミッション:** `kerria.admin.currency`
+フォーマット設定や表示例も確認できます。
 
 ## 為替レート
 
-### `/kerria rate set <fromCurrency> <toCurrency> <rate>`
+<CommandLine command={{
+  command: "/kerria rate set <fromCurrency> <toCurrency> <rate>",
+  description: "通貨ペアの為替レートを設定します。",
+  tags: ["admin"],
+  aliases: [],
+  permission: "kerria.admin.currency",
+  status: "stable"
+}} />
 
-通貨ペアの為替レートを設定します。
 例えば、`/kerria rate set JPY USD 0.0067` とすると、1 JPY = 0.0067 USD になります。
-
-- **パーミッション:** `kerria.admin.currency`

--- a/docs/content/docs/administrator/commands.mdx
+++ b/docs/content/docs/administrator/commands.mdx
@@ -10,6 +10,8 @@ description: サーバー管理者向けコマンドの一覧
 
 プレイヤーの残高を直接操作するコマンドです。
 
+### 残高設定
+
 <CommandLine command={{
   command: "/kerria set <player> <amount> [currencyId]",
   aliases: [],
@@ -20,6 +22,8 @@ description: サーバー管理者向けコマンドの一覧
 
 - **パーミッション:** `kerria.admin.economy`
 
+### 残高付与
+
 <CommandLine command={{
   command: "/kerria give <player> <amount> [currencyId]",
   aliases: [],
@@ -29,6 +33,8 @@ description: サーバー管理者向けコマンドの一覧
 指定したプレイヤーに金額を付与します。
 
 - **パーミッション:** `kerria.admin.economy`
+
+### 残高徴収
 
 <CommandLine command={{
   command: "/kerria take <player> <amount> [currencyId]",
@@ -54,6 +60,8 @@ description: サーバー管理者向けコマンドの一覧
 
 ## 通貨管理
 
+### 通貨作成
+
 <CommandLine command={{
   command: "/kerria currency create <name> <symbol> [decimals]",
   aliases: [],
@@ -66,6 +74,8 @@ description: サーバー管理者向けコマンドの一覧
 
 - **パーミッション:** `kerria.admin.currency`
 
+### 通貨削除
+
 <CommandLine command={{
   command: "/kerria currency delete <name>",
   aliases: [],
@@ -76,6 +86,8 @@ description: サーバー管理者向けコマンドの一覧
 
 - **パーミッション:** `kerria.admin.currency`
 
+### 通貨一覧
+
 <CommandLine command={{
   command: "/kerria currency list",
   aliases: [],
@@ -85,6 +97,8 @@ description: サーバー管理者向けコマンドの一覧
 登録されている全通貨の一覧を表示します。ID・名前・記号・小数桁数が確認できます。
 
 - **パーミッション:** `kerria.admin.currency`
+
+### 通貨詳細
 
 <CommandLine command={{
   command: "/kerria currency info <name>",

--- a/docs/content/docs/administrator/commands.mdx
+++ b/docs/content/docs/administrator/commands.mdx
@@ -12,100 +12,99 @@ description: サーバー管理者向けコマンドの一覧
 
 <CommandLine command={{
   command: "/kerria set <player> <amount> [currencyId]",
-  description: "指定したプレイヤーの残高を直接設定します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.economy",
   status: "stable"
 }} />
+
+指定したプレイヤーの残高を直接設定します。
+
+- **パーミッション:** `kerria.admin.economy`
 
 <CommandLine command={{
   command: "/kerria give <player> <amount> [currencyId]",
-  description: "指定したプレイヤーに金額を付与します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.economy",
   status: "stable"
 }} />
+
+指定したプレイヤーに金額を付与します。
+
+- **パーミッション:** `kerria.admin.economy`
 
 <CommandLine command={{
   command: "/kerria take <player> <amount> [currencyId]",
-  description: "指定したプレイヤーから金額を徴収します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.economy",
   status: "stable"
 }} />
 
-残高が不足している場合、takeコマンドはエラーになります。
+指定したプレイヤーから金額を徴収します。残高が不足している場合はエラーになります。
+
+- **パーミッション:** `kerria.admin.economy`
 
 ## 取引履歴の閲覧
 
 <CommandLine command={{
   command: "/kerria log player <player> [page]",
-  description: "指定したプレイヤーの取引履歴を表示します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.log",
   status: "stable"
 }} />
+
+指定したプレイヤーの取引履歴を表示します。
+
+- **パーミッション:** `kerria.admin.log`
 
 ## 通貨管理
 
 <CommandLine command={{
   command: "/kerria currency create <name> <symbol> [decimals]",
-  description: "新しい通貨を登録します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.currency",
   status: "stable"
 }} />
 
+新しい通貨を登録します。
 `decimals` は小数点以下の桁数で、省略時は 2 になります。
 フォーマットはデフォルトで `%amount% <name>` が設定されます。
 
+- **パーミッション:** `kerria.admin.currency`
+
 <CommandLine command={{
   command: "/kerria currency delete <name>",
-  description: "通貨を削除します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.currency",
   status: "stable"
 }} />
 
-デフォルト通貨は削除できません。
+通貨を削除します。デフォルト通貨は削除できません。
+
+- **パーミッション:** `kerria.admin.currency`
 
 <CommandLine command={{
   command: "/kerria currency list",
-  description: "登録されている全通貨の一覧を表示します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.currency",
   status: "stable"
 }} />
 
-ID・名前・記号・小数桁数が確認できます。
+登録されている全通貨の一覧を表示します。ID・名前・記号・小数桁数が確認できます。
+
+- **パーミッション:** `kerria.admin.currency`
 
 <CommandLine command={{
   command: "/kerria currency info <name>",
-  description: "指定した通貨の詳細情報を表示します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.currency",
   status: "stable"
 }} />
 
-フォーマット設定や表示例も確認できます。
+指定した通貨の詳細情報を表示します。フォーマット設定や表示例も確認できます。
+
+- **パーミッション:** `kerria.admin.currency`
 
 ## 為替レート
 
 <CommandLine command={{
   command: "/kerria rate set <fromCurrency> <toCurrency> <rate>",
-  description: "通貨ペアの為替レートを設定します。",
-  tags: ["admin"],
   aliases: [],
-  permission: "kerria.admin.currency",
   status: "stable"
 }} />
 
+通貨ペアの為替レートを設定します。
 例えば、`/kerria rate set JPY USD 0.0067` とすると、1 JPY = 0.0067 USD になります。
+
+- **パーミッション:** `kerria.admin.currency`

--- a/docs/content/docs/player/commands.mdx
+++ b/docs/content/docs/player/commands.mdx
@@ -10,64 +10,64 @@ description: プレイヤー向けコマンドの一覧
 
 <CommandLine command={{
   command: "/kerria balance [currencyId]",
-  description: "自分の残高を確認します。",
-  tags: ["player"],
   aliases: [],
-  permission: "kerria.balance",
   status: "stable"
 }} />
 
+自分の残高を確認します。
 通貨IDを指定すると、その通貨の残高を表示します。省略時はデフォルト通貨（ID: 1）が使用されます。
+
+- **パーミッション:** `kerria.balance`
 
 ## 送金
 
 <CommandLine command={{
   command: "/kerria pay <player> <amount> [currencyId]",
-  description: "指定したプレイヤーに送金します。",
-  tags: ["player"],
   aliases: [],
-  permission: "kerria.pay",
   status: "stable"
 }} />
 
+指定したプレイヤーに送金します。
 自分自身への送金はできません。残高が不足している場合はエラーになります。
+
+- **パーミッション:** `kerria.pay`
 
 ## ランキング
 
 <CommandLine command={{
   command: "/kerria top [currencyId] [page]",
-  description: "残高ランキングを表示します。",
-  tags: ["player"],
   aliases: [],
-  permission: "kerria.top",
   status: "stable"
 }} />
 
+残高ランキングを表示します。
 通貨やページ番号を指定してフィルタリングできます。1ページあたり10件表示され、次ページへのクリック可能なリンクが表示されます。
+
+- **パーミッション:** `kerria.top`
 
 ## 取引履歴
 
 <CommandLine command={{
   command: "/kerria log [page]",
-  description: "自分の取引履歴を表示します。",
-  tags: ["player"],
   aliases: [],
-  permission: "kerria.log",
   status: "stable"
 }} />
 
+自分の取引履歴をページ送りで表示します。
 各エントリには日時・金額・取引を実行したプラグイン名が含まれます。
+
+- **パーミッション:** `kerria.log`
 
 ## 通貨変換
 
 <CommandLine command={{
   command: "/kerria convert <amount> <fromCurrency> <toCurrency>",
-  description: "為替レートに基づいて通貨を変換します。",
-  tags: ["player"],
   aliases: [],
-  permission: "kerria.convert",
   status: "stable"
 }} />
 
+為替レートに基づいて通貨を変換します。
 変換元通貨の残高から引き落とし、レートに基づいた金額を変換先通貨に入金します。
 事前に管理者がレートを設定している必要があります。
+
+- **パーミッション:** `kerria.convert`

--- a/docs/content/docs/player/commands.mdx
+++ b/docs/content/docs/player/commands.mdx
@@ -8,46 +8,66 @@ description: プレイヤー向けコマンドの一覧
 
 ## 残高確認
 
-### `/kerria balance [currencyId]`
+<CommandLine command={{
+  command: "/kerria balance [currencyId]",
+  description: "自分の残高を確認します。",
+  tags: ["player"],
+  aliases: [],
+  permission: "kerria.balance",
+  status: "stable"
+}} />
 
-自分の残高を確認します。
 通貨IDを指定すると、その通貨の残高を表示します。省略時はデフォルト通貨（ID: 1）が使用されます。
-
-- **パーミッション:** `kerria.balance`
 
 ## 送金
 
-### `/kerria pay <player> <amount> [currencyId]`
+<CommandLine command={{
+  command: "/kerria pay <player> <amount> [currencyId]",
+  description: "指定したプレイヤーに送金します。",
+  tags: ["player"],
+  aliases: [],
+  permission: "kerria.pay",
+  status: "stable"
+}} />
 
-指定したプレイヤーに送金します。
 自分自身への送金はできません。残高が不足している場合はエラーになります。
-
-- **パーミッション:** `kerria.pay`
 
 ## ランキング
 
-### `/kerria top [currencyId] [page]`
+<CommandLine command={{
+  command: "/kerria top [currencyId] [page]",
+  description: "残高ランキングを表示します。",
+  tags: ["player"],
+  aliases: [],
+  permission: "kerria.top",
+  status: "stable"
+}} />
 
-残高ランキングを表示します。
 通貨やページ番号を指定してフィルタリングできます。1ページあたり10件表示され、次ページへのクリック可能なリンクが表示されます。
-
-- **パーミッション:** `kerria.top`
 
 ## 取引履歴
 
-### `/kerria log [page]`
+<CommandLine command={{
+  command: "/kerria log [page]",
+  description: "自分の取引履歴を表示します。",
+  tags: ["player"],
+  aliases: [],
+  permission: "kerria.log",
+  status: "stable"
+}} />
 
-自分の取引履歴をページ送りで表示します。
 各エントリには日時・金額・取引を実行したプラグイン名が含まれます。
-
-- **パーミッション:** `kerria.log`
 
 ## 通貨変換
 
-### `/kerria convert <amount> <fromCurrency> <toCurrency>`
+<CommandLine command={{
+  command: "/kerria convert <amount> <fromCurrency> <toCurrency>",
+  description: "為替レートに基づいて通貨を変換します。",
+  tags: ["player"],
+  aliases: [],
+  permission: "kerria.convert",
+  status: "stable"
+}} />
 
-為替レートに基づいて通貨を変換します。
 変換元通貨の残高から引き落とし、レートに基づいた金額を変換先通貨に入金します。
 事前に管理者がレートを設定している必要があります。
-
-- **パーミッション:** `kerria.convert`

--- a/docs/types/command.ts
+++ b/docs/types/command.ts
@@ -13,24 +13,9 @@ export interface Command {
     command: string;
 
     /**
-     * コマンドの説明
-     */
-    description: string;
-
-    /**
-     * コマンドのタグ
-     */
-    tags: string[];
-
-    /**
      * コマンドのエイリアス
      */
     aliases: string[];
-
-    /**
-     * コマンドのパーミッション
-     */
-    permission: string;
 
     /**
      * コマンドのステータス


### PR DESCRIPTION
## Summary
- プレイヤーコマンドと管理者コマンドのドキュメントで、既存の `CommandLine` コンポーネントを使用するように変更
- コマンドの詳細な説明は平文で記述を維持
- ステータスバッジ付きのインタラクティブな表示、ポップオーバーでパーミッション情報を確認可能に

## Test plan
- [ ] docs devサーバーでプレイヤーコマンドページの表示を確認
- [ ] docs devサーバーで管理者コマンドページの表示を確認
- [ ] 各コマンドのポップオーバーが正しく動作することを確認