### PR TITLE
✨ Add configurable initial balance for new players

### DIFF
--- a/api/src/main/kotlin/party/morino/kerria/api/files/Config.kt
+++ b/api/src/main/kotlin/party/morino/kerria/api/files/Config.kt
@@ -43,6 +43,8 @@ data class DatabaseConfig(
 data class EconomyConfig(
     @YamlComment("小数点以下の桁数")
     val fractionalDigits : Int = 2,
+    @YamlComment("新規プレイヤーの初期残高（デフォルト通貨）")
+    val initialBalance : Double = 0.0,
     val currency : CurrencyConfig = CurrencyConfig()
 )
 

--- a/docs/content/docs/administrator/configuration.mdx
+++ b/docs/content/docs/administrator/configuration.mdx
@@ -1,0 +1,58 @@
+---
+title: 設定ファイル
+description: Kerriaの設定ファイル (config.yml) の解説
+---
+
+Kerriaの設定は `plugins/Kerria/config.yml` に記述します。
+
+## 設定項目
+
+```yaml
+# デバッグモード
+debug: false
+
+economy:
+  # 小数点以下の桁数
+  fractionalDigits: 2
+  # 新規プレイヤーの初期残高（デフォルト通貨）
+  initialBalance: 0.0
+  currency:
+    # 通貨ID
+    id: 1
+    # 通貨名
+    name: JPY
+    # 通貨記号
+    symbol: "¥"
+    # 通貨複数形
+    plural: 円
+    # 通貨フォーマット
+    format: "%amount% %plural%"
+    # 小数点以下の桁数
+    fractionalDigits: 2
+
+database:
+  # データベースの種類 (sqlite | postgresql)
+  mode: sqlite
+  host: localhost
+  port: 5432
+  database: kerria
+  username: user
+  password: password
+```
+
+## economy
+
+### initialBalance
+
+新規プレイヤーがサーバーに初めて参加した際に、デフォルト通貨で付与される初期残高です。
+デフォルト値は `0.0` で、初期残高は付与されません。
+
+例えば `1000.0` に設定すると、新規プレイヤーはアカウント作成時に自動で 1000 が付与されます。
+
+### currency
+
+デフォルト通貨の設定です。プラグイン初回起動時にこの設定を元に通貨が作成されます。
+
+## database
+
+データベースの接続設定です。`sqlite` と `postgresql` をサポートしています。

--- a/docs/content/docs/administrator/meta.json
+++ b/docs/content/docs/administrator/meta.json
@@ -3,6 +3,7 @@
     "icon": "Settings",
     "pages": [
         "commands",
+        "configuration",
         "permissions",
         "...format"
     ]

--- a/paper/src/main/kotlin/party/morino/kerria/paper/account/AccountManagerImpl.kt
+++ b/paper/src/main/kotlin/party/morino/kerria/paper/account/AccountManagerImpl.kt
@@ -10,6 +10,7 @@ import party.morino.kerria.api.account.Account
 import party.morino.kerria.api.account.AccountManager
 import party.morino.kerria.api.account.AccountType
 import party.morino.kerria.api.error.KerriaError
+import party.morino.kerria.api.files.ConfigManager
 import party.morino.kerria.paper.database.repository.AccountRepository
 import java.math.BigDecimal
 import java.util.UUID
@@ -22,6 +23,7 @@ import java.util.UUID
  */
 class AccountManagerImpl : AccountManager, KoinComponent {
     private val accountRepository: AccountRepository by inject()
+    private val configManager: ConfigManager by inject()
 
     override fun getAccount(playerUniqueId: UUID): Either<KerriaError, Account> = runCatching {
         transaction {
@@ -42,7 +44,16 @@ class AccountManagerImpl : AccountManager, KoinComponent {
                 }
                 // 新規作成を試みる（競合時は制約例外が発生する）
                 try {
-                    accountRepository.create(playerUniqueId, playerName).right()
+                    val account = accountRepository.create(playerUniqueId, playerName)
+                    // 初期残高が設定されていればデフォルト通貨で残高を付与
+                    val config = configManager.getConfig()
+                    val initialBalance = BigDecimal.valueOf(config.economy.initialBalance)
+                    if (initialBalance > BigDecimal.ZERO) {
+                        val currencyId = config.economy.currency.id
+                        accountRepository.ensureBalanceRow(account.accountId, currencyId)
+                        accountRepository.setBalance(account.accountId, currencyId, initialBalance)
+                    }
+                    account.right()
                 } catch (_: Exception) {
                     // 制約例外 = 並行で作成済み → 再取得する
                     accountRepository.findByPlayerUniqueId(playerUniqueId)?.right()


### PR DESCRIPTION
Closes #113

## Summary
- `economy.initialBalance` を config.yml に追加。新規プレイヤーのアカウント作成時にデフォルト通貨で初期残高を付与
- `AccountManagerImpl.getOrCreateAccount()` で新規作成時に初期残高を設定
- 管理者向け設定ファイルのドキュメントページを追加

## Test plan
- [ ] デフォルト設定 (`initialBalance: 0.0`) で新規プレイヤーの残高が0であることを確認
- [ ] `initialBalance: 1000.0` に設定して新規プレイヤーが1000から始まることを確認
- [ ] 既存プレイヤーの残高が影響を受けないことを確認